### PR TITLE
testing/ostest: Replace up_tls_info with tls_get_info

### DIFF
--- a/testing/ostest/tls.c
+++ b/testing/ostest/tls.c
@@ -29,12 +29,17 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
 #include "ostest.h"
 
 #if CONFIG_TLS_NELEM > 0
+
+/****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+#define copy_tls_info(a, b) memcpy(a, b, sizeof(struct tls_info_s))
 
 /****************************************************************************
  * Private Data
@@ -48,17 +53,17 @@ static struct tls_info_s g_save_info;
 
 static void get_tls_info(FAR struct tls_info_s *info)
 {
-  memcpy(info, up_tls_info(), sizeof(struct tls_info_s));
+  copy_tls_info(info, tls_get_info());
 }
 
 static void put_tls_info(FAR const struct tls_info_s *info)
 {
-  memcpy(up_tls_info(), info, sizeof(struct tls_info_s));
+  copy_tls_info(tls_get_info(), info);
 }
 
 static void set_tls_info(uintptr_t value)
 {
-  FAR struct tls_info_s *info = up_tls_info();
+  FAR struct tls_info_s *info = tls_get_info();
   int i;
 
   for (i = 0; i < CONFIG_TLS_NELEM; i++)
@@ -69,7 +74,7 @@ static void set_tls_info(uintptr_t value)
 
 static bool verify_tls_info(uintptr_t value)
 {
-  FAR struct tls_info_s *info = up_tls_info();
+  FAR struct tls_info_s *info = tls_get_info();
   bool fail = false;
   int i;
 


### PR DESCRIPTION
follow the kernel side change

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>

## Summary

## Impact

## Testing

