### PR TITLE
Imx9 secure world

### DIFF
--- a/examples/optee/CMakeLists.txt
+++ b/examples/optee/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/optee/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_OPTEE)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_OPTEE_PROGNAME}
+    SRCS
+    optee_main.c
+    STACKSIZE
+    ${CONFIG_EXAMPLES_OPTEE_STACKSIZE}
+    PRIORITY
+    ${CONFIG_EXAMPLES_OPTEE_PRIORITY})
+endif()

--- a/examples/optee/Kconfig
+++ b/examples/optee/Kconfig
@@ -1,0 +1,29 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_OPTEE
+	tristate "OP-TEE client example"
+	default n
+	---help---
+		Enable the OP-TEE client example
+
+if EXAMPLES_OPTEE
+
+config EXAMPLES_OPTEE_PROGNAME
+	string "Program name"
+	default "optee"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_OPTEE_PRIORITY
+	int "OP-TEE task priority"
+	default 100
+
+config EXAMPLES_OPTEE_STACKSIZE
+	int "OP-TEE stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/optee/Make.defs
+++ b/examples/optee/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/optee/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_OPTEE),)
+CONFIGURED_APPS += $(APPDIR)/examples/optee
+endif

--- a/examples/optee/Makefile
+++ b/examples/optee/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/examples/optee/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# OP-TEE client built-in application info
+
+PROGNAME  = $(CONFIG_EXAMPLES_OPTEE_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_OPTEE_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_OPTEE_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_OPTEE)
+
+MAINSRC = optee_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/optee/optee_main.c
+++ b/examples/optee/optee_main.c
@@ -1,0 +1,410 @@
+/****************************************************************************
+ * apps/examples/optee/optee_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <nuttx/tee.h>
+#include <uuid.h>
+
+/****************************************************************************
+ * Pre-processor definitions
+ ****************************************************************************/
+
+#define OPTEE_DEV                 "/dev/tee0"
+
+#define PTA_DEVICE_ENUM           { 0x7011a688, 0xddde, 0x4053, \
+                                    0xa5, 0xa9, \
+                                    { 0x7b, 0x3c, 0x4d, 0xdf, 0x13, 0xb8 } }
+
+#define PTA_CMD_GET_DEVICES       0x0
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+typedef struct tee_shm
+{
+  int fd;
+  size_t size;
+  void *ptr;
+  int32_t id;
+} tee_shm_t;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int tee_check_version_and_caps(int fd, uint32_t *caps)
+{
+  struct tee_ioctl_version_data ioc_ver;
+  int ret;
+
+  ret = ioctl(fd, TEE_IOC_VERSION, (unsigned long)&ioc_ver);
+  if (ret < 0)
+    {
+      printf("Failed to query TEE driver version and caps: %d, %s\n",
+             ret, strerror(errno));
+      return ret;
+    }
+
+  if (ioc_ver.impl_id != TEE_IMPL_ID_OPTEE)
+    {
+      printf("Not an OP-TEE implementation\n");
+      return -ENOTSUP;
+    }
+
+  if (!(ioc_ver.impl_caps & TEE_OPTEE_CAP_TZ))
+    {
+      printf("OP-TEE TrustZone not supported\n");
+      return -ENOTSUP;
+    }
+
+  if (((TEE_GEN_CAP_GP | TEE_GEN_CAP_MEMREF_NULL) & ioc_ver.gen_caps) !=
+       (TEE_GEN_CAP_GP | TEE_GEN_CAP_MEMREF_NULL))
+    {
+      printf("CAP_GP or MEMREF_NULL not supported\n");
+      return -ENOTSUP;
+    }
+
+  printf("impl id: %u, impl caps: %u, gen caps: %u\n",
+         ioc_ver.impl_id, ioc_ver.impl_caps, ioc_ver.gen_caps);
+
+  if (caps)
+    {
+      *caps = ioc_ver.gen_caps;
+    }
+
+  return ret;
+}
+
+static int tee_open_session(int fd, const uuid_t *uuid, uint32_t *session)
+{
+  struct tee_ioctl_open_session_arg ioc_opn;
+  struct tee_ioctl_buf_data ioc_buf;
+  int ret;
+
+  memset(&ioc_opn, 0, sizeof(struct tee_ioctl_open_session_arg));
+
+  uuid_enc_be(&ioc_opn.uuid, uuid);
+
+  ioc_buf.buf_ptr = (uintptr_t)&ioc_opn;
+  ioc_buf.buf_len = sizeof(struct tee_ioctl_open_session_arg);
+
+  ret = ioctl(fd, TEE_IOC_OPEN_SESSION, (unsigned long)&ioc_buf);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  if (session)
+    {
+      *session = ioc_opn.session;
+    }
+
+  return ret;
+}
+
+static int tee_invoke(int fd, uint32_t session, uint32_t func,
+                      struct tee_ioctl_param *params, size_t num_params)
+{
+  struct tee_ioctl_invoke_arg *ioc_args;
+  struct tee_ioctl_buf_data ioc_buf;
+  size_t ioc_args_len;
+  int ret;
+
+  ioc_args_len = sizeof(struct tee_ioctl_invoke_arg) +
+                 TEE_IOCTL_PARAM_SIZE(num_params);
+
+  ioc_args = (struct tee_ioctl_invoke_arg *)calloc(1, ioc_args_len);
+  if (!ioc_args)
+    {
+      return -ENOMEM;
+    }
+
+  ioc_args->func = func;
+  ioc_args->session = session;
+  ioc_args->num_params = num_params;
+  memcpy(&ioc_args->params, params, TEE_IOCTL_PARAM_SIZE(num_params));
+
+  ioc_buf.buf_ptr = (uintptr_t)ioc_args;
+  ioc_buf.buf_len = ioc_args_len;
+
+  ret = ioctl(fd, TEE_IOC_INVOKE, (unsigned long)&ioc_buf);
+  if (ret < 0)
+    {
+      goto err_with_args;
+    }
+
+  memcpy(params, &ioc_args->params, TEE_IOCTL_PARAM_SIZE(num_params));
+
+err_with_args:
+  free(ioc_args);
+
+  return ret;
+}
+
+static int tee_shm_register(int fd, tee_shm_t *shm)
+{
+  struct tee_ioctl_shm_register_data ioc_reg;
+
+  memset(&ioc_reg, 0, sizeof(struct tee_ioctl_shm_register_data));
+
+  if (!shm)
+    {
+      return -EINVAL;
+    }
+
+  shm->id = (int32_t)(uintptr_t)shm->ptr;
+
+  ioc_reg.addr = (uintptr_t)shm->ptr;
+  ioc_reg.length = shm->size;
+  ioc_reg.flags = TEE_SHM_REGISTER | TEE_SHM_SEC_REGISTER;
+  ioc_reg.id = shm->id;
+
+  return ioctl(fd, TEE_IOC_SHM_REGISTER, (unsigned long)&ioc_reg);
+}
+
+#if 0 /* Not used */
+static int tee_shm_mmap(int fd, tee_shm_t *shm, bool reg)
+{
+  struct tee_ioctl_shm_alloc_data ioc_alloc;
+  int ret = 0;
+
+  memset(&ioc_alloc, 0, sizeof(struct tee_ioctl_shm_alloc_data));
+
+  if (!shm)
+    {
+      return -EINVAL;
+    }
+
+  ioc_alloc.size = shm->size;
+
+  shm->fd = ioctl(fd, TEE_IOC_SHM_ALLOC, (unsigned long)&ioc_alloc);
+  if (shm->fd < 0)
+    {
+      return shm->fd;
+    }
+
+  shm->ptr = mmap(NULL, shm->size, PROT_READ | PROT_WRITE, MAP_SHARED,
+                  shm->fd, 0);
+  if (shm->ptr == MAP_FAILED)
+    {
+      close(shm->fd);
+      return -ENOMEM;
+    }
+
+  if (reg)
+    {
+      ret = tee_shm_register(fd, shm);
+      if (ret < 0)
+        {
+          munmap(shm->ptr, shm->size);
+          close(shm->fd);
+          return ret;
+        }
+    }
+
+  return ret;
+}
+#endif
+
+static int tee_shm_alloc(int fd, tee_shm_t *shm, bool reg)
+{
+  int ret = 0;
+
+  if (!shm)
+    {
+      return -EINVAL;
+    }
+
+  shm->ptr = malloc(shm->size);
+  if (!shm->ptr)
+    {
+      return -ENOMEM;
+    }
+
+  shm->fd = -1;
+
+  if (reg)
+    {
+      ret = tee_shm_register(fd, shm);
+      if (ret < 0)
+        {
+          free(shm->ptr);
+        }
+    }
+
+  return ret;
+}
+
+static void tee_shm_free(tee_shm_t *shm)
+{
+  if (!shm)
+    {
+      return;
+    }
+
+  if (shm->fd > 0)
+    {
+      /* Allocated via tee_shm_mmap() */
+
+      munmap(shm->ptr, shm->size);
+      close(shm->fd);
+    }
+  else
+    {
+      /* Allocated via tee_shm_alloc() */
+
+      free(shm->ptr);
+    }
+
+  shm->ptr = NULL;
+  shm->fd = -1;
+}
+
+static int tee_close_session(int fd, uint32_t session)
+{
+  struct tee_ioctl_close_session_arg ioc_close;
+  int ret;
+
+  ioc_close.session = session;
+
+  ret = ioctl(fd, TEE_IOC_CLOSE_SESSION, (unsigned long)&ioc_close);
+
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * optee_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  int fd;
+  uint32_t caps;
+  const uuid_t pta_dvc_uuid = PTA_DEVICE_ENUM;
+  uint32_t session;
+  struct tee_ioctl_param par0;
+  tee_shm_t shm;
+  unsigned int count;
+  const uuid_t *raw_ta_uuid;
+  uuid_t ta_uuid;
+  char *ta_uuid_s;
+  int ret;
+
+  memset(&par0, 0, sizeof(struct tee_ioctl_param));
+  memset(&shm, 0, sizeof(tee_shm_t));
+
+  fd = open(OPTEE_DEV, O_RDONLY | O_NONBLOCK);
+  if (fd < 0)
+    {
+      printf("Failed to open " OPTEE_DEV ": %s\n", strerror(errno));
+      return -errno;
+    }
+
+  ret = tee_check_version_and_caps(fd, &caps);
+  if (ret < 0)
+    {
+      goto err;
+    }
+
+  ret = tee_open_session(fd, &pta_dvc_uuid, &session);
+  if (ret < 0)
+    {
+      printf("Failed to open session with devices.pta: %d, %s\n",
+             ret, strerror(errno));
+      goto err;
+    }
+
+  par0.attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT;
+
+  ret = tee_invoke(fd, session, PTA_CMD_GET_DEVICES, &par0, 1);
+  if (ret < 0)
+    {
+      printf("Failed to get size needed for device enumeration: %d, %s\n",
+             ret, strerror(errno));
+      goto err_with_session;
+    }
+
+  shm.size = par0.b;
+
+  ret = tee_shm_alloc(fd, &shm, caps & TEE_GEN_CAP_REG_MEM);
+  if (ret < 0)
+    {
+      printf("Failed to allocate shared memory: %d, %s\n",
+             ret, strerror(errno));
+      goto err_with_session;
+    }
+
+  par0.attr = TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT;
+  par0.a = 0;
+  par0.b = shm.size;
+  par0.c = (uintptr_t)shm.ptr;
+
+  ret = tee_invoke(fd, session, PTA_CMD_GET_DEVICES, &par0, 1);
+  if (ret < 0)
+    {
+      printf("Failed to enumerate devices: %d, %s\n", ret, strerror(errno));
+      goto err_with_shm;
+    }
+
+  printf("Available devices:\n");
+
+  count = par0.b / sizeof(uuid_t);
+  raw_ta_uuid = (uuid_t *)shm.ptr;
+
+  while (count--)
+    {
+      uuid_dec_be(raw_ta_uuid, &ta_uuid);
+      uuid_to_string(&ta_uuid, &ta_uuid_s, NULL);
+
+      printf("  %s\n", ta_uuid_s);
+
+      free(ta_uuid_s);
+      raw_ta_uuid++;
+    }
+
+err_with_shm:
+  tee_shm_free(&shm);
+
+err_with_session:
+  tee_close_session(fd, session);
+
+err:
+  close(fd);
+
+  return ret;
+}

--- a/examples/optee_gp/CMakeLists.txt
+++ b/examples/optee_gp/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ##############################################################################
+# apps/examples/optee_gp/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_EXAMPLES_OPTEE_GP)
+  nuttx_add_application(
+    NAME
+    ${CONFIG_EXAMPLES_OPTEE_GP_PROGNAME}
+    SRCS
+    optee_gp_main.c
+    STACKSIZE
+    ${CONFIG_EXAMPLES_OPTEE_GP_STACKSIZE}
+    PRIORITY
+    ${CONFIG_EXAMPLES_OPTEE_GP_PRIORITY})
+endif()

--- a/examples/optee_gp/Kconfig
+++ b/examples/optee_gp/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_OPTEE_GP
+	tristate "OP-TEE GP API client example"
+	depends on LIBTEEC
+	default n
+	---help---
+		Enable the OP-TEE GP API client example which uses libteec
+
+if EXAMPLES_OPTEE
+
+config EXAMPLES_OPTEE_GP_PROGNAME
+	string "Program name"
+	default "optee_gp"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_OPTEE_GP_PRIORITY
+	int "OP-TEE GP task priority"
+	default 100
+
+config EXAMPLES_OPTEE_GP_STACKSIZE
+	int "OP-TEE GP stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/optee_gp/Kconfig
+++ b/examples/optee_gp/Kconfig
@@ -10,7 +10,7 @@ config EXAMPLES_OPTEE_GP
 	---help---
 		Enable the OP-TEE GP API client example which uses libteec
 
-if EXAMPLES_OPTEE
+if EXAMPLES_OPTEE_GP
 
 config EXAMPLES_OPTEE_GP_PROGNAME
 	string "Program name"

--- a/examples/optee_gp/Make.defs
+++ b/examples/optee_gp/Make.defs
@@ -1,0 +1,25 @@
+############################################################################
+# apps/examples/optee_gp/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_OPTEE_GP),)
+CONFIGURED_APPS += $(APPDIR)/examples/optee_gp
+endif

--- a/examples/optee_gp/Makefile
+++ b/examples/optee_gp/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/examples/optee_gp/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# OP-TEE GP API client built-in application info
+
+PROGNAME  = $(CONFIG_EXAMPLES_OPTEE_GP_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_OPTEE_GP_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_OPTEE_GP_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_OPTEE_GP)
+
+MAINSRC = optee_gp_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/optee_gp/optee_gp_main.c
+++ b/examples/optee_gp/optee_gp_main.c
@@ -1,0 +1,190 @@
+/****************************************************************************
+ * apps/examples/optee_gp/optee_gp_main.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/tee.h>
+#include <tee_client_api.h>
+#include <teec_trace.h>
+#include <uuid.h>
+
+/****************************************************************************
+ * Pre-processor definitions
+ ****************************************************************************/
+
+/* This UUID is taken from the OP-TEE OS built-in pseudo TA:
+ * https://github.com/OP-TEE/optee_os/blob/4.6.0/
+ *   lib/libutee/include/pta_device.h
+ */
+#define PTA_DEVICE_ENUM_UUID                               \
+    {                                                      \
+      0x7011a688, 0xddde, 0x4053,                          \
+        {                                                  \
+            0xa5, 0xa9, 0x7b, 0x3c, 0x4d, 0xdf, 0x13, 0xb8 \
+        }                                                  \
+    }
+
+#define PTA_CMD_GET_DEVICES 0x0
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * optee_gp_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  TEEC_Result res;
+  TEEC_Context ctx;
+  TEEC_Session sess;
+  TEEC_Operation op;
+  TEEC_UUID uuid = PTA_DEVICE_ENUM_UUID;
+  void *buf;
+  TEEC_SharedMemory io_shm;
+  uint32_t err_origin;
+  unsigned int count;
+  const uuid_t *raw_ta_uuid;
+  uuid_t ta_uuid;
+  char *ta_uuid_s;
+
+  res = TEEC_InitializeContext(NULL, &ctx);
+  if (res != TEEC_SUCCESS)
+    {
+      EMSG("TEEC_InitializeContext failed with code 0x%08x\n", res);
+      goto exit;
+    }
+
+  memset(&op, 0, sizeof(op));
+
+  /* Open a session with the devices pseudo TA */
+
+  res = TEEC_OpenSession(&ctx, &sess, &uuid, TEEC_LOGIN_PUBLIC, NULL,
+                         &op, &err_origin);
+  if (res != TEEC_SUCCESS)
+    {
+      EMSG("TEEC_Opensession failed with code 0x%08x origin 0x%08x", res,
+           err_origin);
+      goto exit_with_ctx;
+    }
+
+  /* Invoke command with NULL buffer to get required size */
+
+  op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_OUTPUT, TEEC_NONE,
+                                   TEEC_NONE, TEEC_NONE);
+  op.params[0].tmpref.buffer = NULL;
+  op.params[0].tmpref.size = 0;
+
+  res = TEEC_InvokeCommand(&sess, PTA_CMD_GET_DEVICES, &op, &err_origin);
+  if (err_origin != TEEC_ORIGIN_TRUSTED_APP ||
+      res != TEEC_ERROR_SHORT_BUFFER)
+    {
+      EMSG("TEEC_InvokeCommand failed: code 0x%08x origin 0x%08x",
+          res, err_origin);
+      goto exit_with_session;
+    }
+
+  /* Invoke command using temporary memory */
+
+  op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_OUTPUT, TEEC_NONE,
+                                   TEEC_NONE, TEEC_NONE);
+
+  op.params[0].tmpref.buffer = buf = malloc(op.params[0].tmpref.size);
+  if (!op.params[0].tmpref.buffer)
+    {
+      EMSG("Failed to allocate %zu bytes of memory to share with TEE",
+           op.params[0].tmpref.size);
+      goto exit_with_session;
+    }
+
+  res = TEEC_InvokeCommand(&sess, PTA_CMD_GET_DEVICES, &op, &err_origin);
+  if (res != TEEC_SUCCESS)
+    {
+      EMSG("TEEC_InvokeCommand failed: code 0x%08x origin 0x%08x",
+          res, err_origin);
+      goto exit_with_buf;
+    }
+
+  /* Invoke command using pre-allocated, pre-registered memory */
+
+  io_shm.size = op.params[0].tmpref.size;
+  io_shm.flags = TEEC_MEM_OUTPUT;
+  res = TEEC_AllocateSharedMemory(&ctx, &io_shm);
+  if (res != TEEC_SUCCESS)
+    {
+      EMSG("TEEC_AllocateSharedMemory failed: code 0x%08x", res);
+      goto exit_with_buf;
+    }
+
+  op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_WHOLE, TEEC_NONE, TEEC_NONE,
+                                   TEEC_NONE);
+  op.params[0].memref.parent = &io_shm;
+
+  res = TEEC_InvokeCommand(&sess, PTA_CMD_GET_DEVICES, &op, &err_origin);
+  if (res != TEEC_SUCCESS)
+    {
+      EMSG("TEEC_InvokeCommand failed: code 0x%08x origin 0x%08x",
+          res, err_origin);
+      goto exit_with_shm;
+    }
+
+  /* Sanity check that both outputs are the same */
+
+  if (memcmp(buf, io_shm.buffer, io_shm.size))
+    {
+      EMSG("Different results with temp vs registered memory");
+      goto exit_with_shm;
+    }
+
+  /* Print results to stdout */
+
+  IMSG("Available devices:");
+
+  count = io_shm.size / sizeof(uuid_t);
+  raw_ta_uuid = (uuid_t *)io_shm.buffer;
+
+  while (count--)
+    {
+      uuid_dec_be(raw_ta_uuid, &ta_uuid);
+      uuid_to_string(&ta_uuid, &ta_uuid_s, NULL);
+
+      IMSG("  %s", ta_uuid_s);
+
+      free(ta_uuid_s);
+      raw_ta_uuid++;
+    }
+
+exit_with_shm:
+  TEEC_ReleaseSharedMemory(&io_shm);
+exit_with_buf:
+  free(buf);
+exit_with_session:
+  TEEC_CloseSession(&sess);
+exit_with_ctx:
+  TEEC_FinalizeContext(&ctx);
+exit:
+  return res;
+}

--- a/tee/.gitignore
+++ b/tee/.gitignore
@@ -1,0 +1,1 @@
+/Kconfig

--- a/tee/CMakeLists.txt
+++ b/tee/CMakeLists.txt
@@ -1,0 +1,25 @@
+# ##############################################################################
+# apps/tee/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+nuttx_add_subdirectory()
+
+nuttx_generate_kconfig(MENUDESC "TEE Libraries Support")

--- a/tee/Make.defs
+++ b/tee/Make.defs
@@ -1,0 +1,21 @@
+############################################################################
+# apps/tee/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(wildcard $(APPDIR)/tee/*/Make.defs)

--- a/tee/Makefile
+++ b/tee/Makefile
@@ -1,0 +1,23 @@
+############################################################################
+# apps/tee/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+MENUDESC = "TEE Libraries Support"
+
+include $(APPDIR)/Directory.mk

--- a/tee/libteec/.gitignore
+++ b/tee/libteec/.gitignore
@@ -1,0 +1,3 @@
+/optee_client
+/*.zip
+/*.tar.gz

--- a/tee/libteec/0001-libteec-NuttX.patch
+++ b/tee/libteec/0001-libteec-NuttX.patch
@@ -1,0 +1,47 @@
+From 70a12eb84a1276cad15bc2ac867ffad513d5c732 Mon Sep 17 00:00:00 2001
+From: George Poulios <gpoulios@census-labs.com>
+Date: Sun, 11 May 2025 00:44:22 +0300
+Subject: [PATCH] libteec: NuttX patches
+
+Fix use of gettid() syscall in teec_trace.c and
+replace include of linux/tee.h with nuttx/tee.h.
+
+Signed-off-by: George Poulios <gpoulios@census-labs.com>
+---
+ libteec/src/tee_client_api.c | 6 +++++-
+ libteec/src/teec_trace.c     | 2 +-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/libteec/src/tee_client_api.c b/libteec/src/tee_client_api.c
+index 512fdac..b54e0b6 100644
+--- a/libteec/src/tee_client_api.c
++++ b/libteec/src/tee_client_api.c
+@@ -44,7 +44,11 @@
+ #ifndef __aligned
+ #define __aligned(x) __attribute__((__aligned__(x)))
+ #endif
+-#include <linux/tee.h>
++#ifdef __NuttX__
++#  include <nuttx/tee.h>
++#else
++#  include <linux/tee.h>
++#endif
+ 
+ #define MIN(x, y) (((x) < (y)) ? (x) : (y))
+ 
+diff --git a/libteec/src/teec_trace.c b/libteec/src/teec_trace.c
+index 7194c8c..025cc4b 100644
+--- a/libteec/src/teec_trace.c
++++ b/libteec/src/teec_trace.c
+@@ -75,7 +75,7 @@ void _dprintf(const char *function, int line, int level, const char *prefix,
+ 	va_list ap;
+ 
+ 	if (function) {
+-		int thread_id = syscall(SYS_gettid);
++		int thread_id = (int)gettid();
+ 
+ 		n = snprintf(msg, sizeof(msg), "%s [%d] %s:%s:%d: ",
+ 			trace_level_strings[level], thread_id, prefix,
+-- 
+2.34.1
+

--- a/tee/libteec/CMakeLists.txt
+++ b/tee/libteec/CMakeLists.txt
@@ -1,0 +1,59 @@
+# ##############################################################################
+# apps/tee/libteec/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2023 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_LIBTEEC)
+
+  set(OPTEE_CLIENT_DIR ${CMAKE_CURRENT_LIST_DIR}/optee_client)
+
+  if(NOT EXISTS ${OPTEE_CLIENT_DIR})
+    FetchContent_Declare(
+      optee_client_fetch
+      URL https://github.com/OP-TEE/optee_client/archive/refs/tags/${CONFIG_LIBTEEC_VERSION}.tar.gz
+          SOURCE_DIR
+          ${OPTEE_CLIENT_DIR}
+          BINARY_DIR
+          ${CMAKE_BINARY_DIR}/tee/libteec/optee_client
+      PATCH_COMMAND patch -p1 -d ${OPTEE_CLIENT_DIR} <
+                    ${CMAKE_CURRENT_LIST_DIR}/0001-libteec-NuttX.patch
+      DOWNLOAD_NO_PROGRESS true
+      TIMEOUT 30)
+
+    FetchContent_GetProperties(optee_client_fetch)
+
+    if(NOT optee_client_fetch_POPULATED)
+      FetchContent_Populate(optee_client_fetch)
+    endif()
+  endif()
+
+  set_property(
+    TARGET nuttx
+    APPEND
+    PROPERTY NUTTX_INCLUDE_DIRECTORIES ${OPTEE_CLIENT_DIR}/libteec/include)
+
+  nuttx_add_library(libteec STATIC)
+
+  target_sources(libteec PRIVATE optee_client/libteec/src/tee_client_api.c
+                                 optee_client/libteec/src/teec_trace.c)
+  target_include_directories(libteec
+                             PRIVATE ${OPTEE_CLIENT_DIR}/libteec/include)
+  target_compile_definitions(libteec PRIVATE BINARY_PREFIX=\"TEEC\")
+
+endif()

--- a/tee/libteec/Kconfig
+++ b/tee/libteec/Kconfig
@@ -1,0 +1,45 @@
+############################################################################
+# apps/tee/libteec/Kconfig
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2023 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+############################################################################
+
+config LIBTEEC
+	bool "TEE client library (libteec)"
+	default n
+	---help---
+	        Enable libteec from https://github.com/OP-TEE/optee_client. This
+	        is OP-TEE project's implementation of GlobalPlatform's TEE client
+	        API specification v1.0 (GPD_SPE_007):
+	         https://globalplatform.org/specs-library/?filter-committee=tee
+	        The TEE Client API describes and defines how a client running in
+	        a rich operating environment (REE, in this case NuttX) should
+	        communicate with the Trusted Execution Environment (TEE) and its
+	        Trusted Applications (TAs). The library provides a
+	        well-established and easy-to-use interface abstracting away much
+	        of the details of the underlying subsystems. For more information
+	        please refer to:
+	        https://optee.readthedocs.io/en/latest/architecture/globalplatform_api.html#tee-client-api
+
+if LIBTEEC
+
+config LIBTEEC_VERSION
+	string "optee_client version (4.6.0)"
+	default "4.6.0"
+
+endif # LIBTEEC

--- a/tee/libteec/Make.defs
+++ b/tee/libteec/Make.defs
@@ -1,0 +1,46 @@
+############################################################################
+# apps/tee/libteec/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2023 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_LIBTEEC),)
+CONFIGURED_APPS += $(APPDIR)/tee/libteec
+
+FLAGS += ${INCDIR_PREFIX}$(APPDIR)/tee/libteec/optee_client/libteec/include
+FLAGS += ${DEFINE_PREFIX}BINARY_PREFIX="\"TEEC\""
+
+ifneq ($(CONFIG_DEBUG_INFO),)
+  FLAGS += ${DEFINE_PREFIX}DEBUGLEVEL=3
+else ifneq ($(CONFIG_DEBUG_WARN),)
+  FLAGS += ${DEFINE_PREFIX}DEBUGLEVEL=2
+else ifneq ($(CONFIG_DEBUG_ERROR),)
+  FLAGS += ${DEFINE_PREFIX}DEBUGLEVEL=1
+else
+# the default DEBUGLEVEL are 1(with error level)
+  FLAGS += ${DEFINE_PREFIX}DEBUGLEVEL=1
+endif
+
+AFLAGS += $(FLAGS)
+CFLAGS += $(FLAGS)
+CXXFLAGS += $(FLAGS)
+
+DEPPATH += --dep-path libteec
+VPATH += :libteec
+
+endif

--- a/tee/libteec/Makefile
+++ b/tee/libteec/Makefile
@@ -1,0 +1,52 @@
+############################################################################
+# apps/tee/libteec/Makefile
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2023 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+LIBTEEC_VERSION = $(patsubst "%",%,$(strip $(CONFIG_LIBTEEC_VERSION)))
+LIBTEEC_URL ?= "https://github.com/OP-TEE/optee_client/archive/refs/tags"
+LIBTEEC_ZIP = $(LIBTEEC_VERSION).zip
+LIBTEEC_UNPACKNAME = optee_client
+UNPACK ?= unzip -q -o
+
+CSRCS += optee_client/libteec/src/tee_client_api.c
+CSRCS += optee_client/libteec/src/teec_trace.c
+
+$(LIBTEEC_ZIP):
+	@echo "Downloading: $(LIBTEEC_URL)/$(LIBTEEC_ZIP)"
+	$(Q) $(call DOWNLOAD,$(LIBTEEC_URL),$(LIBTEEC_ZIP))
+
+$(LIBTEEC_UNPACKNAME): $(LIBTEEC_ZIP)
+	@echo "Unpacking: $(LIBTEEC_ZIP) -> $(LIBTEEC_UNPACKNAME)"
+	$(Q) $(UNPACK) $(LIBTEEC_ZIP)
+	$(Q) mv $(LIBTEEC_UNPACKNAME)-$(LIBTEEC_VERSION) $(LIBTEEC_UNPACKNAME)
+	$(Q) echo "Patching $(LIBTEEC_UNPACKNAME)"
+	$(Q) patch -p1 -d $(LIBTEEC_UNPACKNAME) < 0001-libteec-NuttX.patch
+	$(Q) touch $(LIBTEEC_UNPACKNAME)
+
+ifeq ($(wildcard $(LIBTEEC_UNPACKNAME)/.git),)
+context:: $(LIBTEEC_UNPACKNAME)
+
+distclean::
+	$(Q) rm -rf $(LIBTEEC_UNPACKNAME)
+endif
+
+include $(APPDIR)/Application.mk


### PR DESCRIPTION
## Summary
This PR adds an example and its dependency (libteec) in order to test communication between nuttx and OP-TEE.
The example, `optee_gp` will query the OP-TEE for the available devices (TAs), the OP-TEE will return the uuids for these devices.

## Impact
No impact to existing applications, it only adds new functionality.

## Testing
In order to test this, an appropriate bootloader must be used that loads TF-A and OP-TEE, also the example must be enabled in nuttx's config. These related PRs are for such a bootloader https://github.com/tiiuae/saluki_bootloader_v2/pull/196 and nuttx/PX4 configuration https://github.com/tiiuae/px4-firmware/pull/975.

If previous requirements are met then we can invoke from the shell the `optee_gp` example and see similar logs:

```
saluki> optee_gp
INF [1736] TEEC:main:164: Available devices:
INF [1736] TEEC:main:174:   d96a5b40-c3e5-21e3-8794-1002a5d5c61b
INF [1736] TEEC:main:174:   f04a0fe7-1f5d-4b9b-abf7-619b85b4ce8c
```

