### PR TITLE
nshlib/nsh_parse.c: Fix empty variable extensions on command line

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -2395,13 +2395,26 @@ static int nsh_parse_cmdparm(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline,
    */
 
   argv[0] = cmd;
-  for (argc = 1; argc < MAX_ARGV_ENTRIES - 1; argc++)
+  argc = 1;
+  while (argc < MAX_ARGV_ENTRIES - 1)
     {
-      argv[argc] = nsh_argument(vtbl, &saveptr, &memlist, NULL, NULL);
-      if (!argv[argc])
+      FAR char *arg = nsh_argument(vtbl, &saveptr, &memlist, NULL, NULL);
+      if (!arg)
         {
           break;
         }
+
+      /* Skip empty arguments resulting from empty variable expansions.
+       * These should be removed from argv, but should not prevent processing
+       * of subsequent arguments.
+       */
+
+      if (*arg == '\0')
+        {
+          continue;
+        }
+
+      argv[argc++] = arg;
     }
 
   argv[argc] = NULL;
@@ -2569,6 +2582,13 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
       if (!argv[argc])
         {
           break;
+        }
+
+      /* Skip empty arguments resulting from empty variable expansions */
+
+      if (*argv[argc] == '\0')
+        {
+          continue;
         }
 
       if (isenvvar != 0)


### PR DESCRIPTION
If empty variables are given on the command line, they should be just skipped from the argument list, and not terminate the argument processing.

Fix the behaviour in:
- nsh_parse_cmdparm (command substitution)
- nsh_parse_command (the main command line parsing)
