### PR TITLE
nshlib/nsh_command.c: file apps cmd tab completion

### DIFF
--- a/nshlib/CMakeLists.txt
+++ b/nshlib/CMakeLists.txt
@@ -55,7 +55,7 @@ if(CONFIG_NSH_LIBRARY)
   endif()
 
   if(CONFIG_NSH_FILE_APPS)
-    list(APPEND CSRCS nsh_fileapps.c)
+    list(APPEND CSRCS nsh_fileapps.c nsh_fileapps_helper.c)
   endif()
 
   if(CONFIG_NSH_VARS)

--- a/nshlib/Makefile
+++ b/nshlib/Makefile
@@ -40,7 +40,7 @@ CSRCS += nsh_builtin.c
 endif
 
 ifeq ($(CONFIG_NSH_FILE_APPS),y)
-CSRCS += nsh_fileapps.c
+CSRCS += nsh_fileapps.c nsh_fileapps_helper.c
 endif
 
 ifeq ($(CONFIG_NSH_VARS),y)

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -859,8 +859,25 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 #endif
 
 #ifdef CONFIG_NSH_FILE_APPS
+/* NOTE: Initialize before first use with NSH_FILE_APP_INFO_INITIALIZER
+ * (or an equivalent helper that zeroes all fields).
+ */
+
+struct file_app_info_s
+{
+  FAR char **names;
+  unsigned int count;
+  unsigned int alloc;
+};
+
+#define NSH_FILE_APP_INFO_INITIALIZER { NULL, 0, 0 }
+
 int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
                 FAR char **argv, FAR const struct nsh_param_s *param);
+int nsh_collect_path_file_apps(FAR struct file_app_info_s *info,
+                               FAR const char *prefix,
+                               int prefix_len);
+void nsh_free_file_apps(FAR struct file_app_info_s *info);
 #endif
 
 /* Working directory support */

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -680,6 +680,12 @@ static const struct cmdmap_s g_cmdmap[] =
   CMD_MAP(NULL,       NULL,         1, 1, NULL)
 };
 
+#if defined(CONFIG_NSH_READLINE) && defined(CONFIG_READLINE_TABCOMPLETION) && \
+    defined(CONFIG_READLINE_HAVE_EXTMATCH) && defined(CONFIG_NSH_FILE_APPS)
+static struct file_app_info_s g_file_app_matches =
+  NSH_FILE_APP_INFO_INITIALIZER;
+#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -1276,7 +1282,7 @@ int nsh_command(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char *argv[])
  * Description:
  *   This support function is used to provide support for realine tab-
  *   completion logic  nsh_extmatch_count() counts the number of matching
- *   nsh command names
+ *   nsh command and file application names
  *
  * Input Parameters:
  *   name    - A point to the name containing the name to be matched.
@@ -1310,6 +1316,28 @@ int nsh_extmatch_count(FAR char *name, FAR int *matches, int namelen)
         }
     }
 
+#ifdef CONFIG_NSH_FILE_APPS
+  if (nr_matches < CONFIG_READLINE_MAX_EXTCMDS)
+    {
+      int ret;
+      ret = nsh_collect_path_file_apps(&g_file_app_matches, name, namelen);
+
+      if (ret >= 0)
+        {
+          for (i = 0; i < (int)g_file_app_matches.count; i++)
+            {
+              matches[nr_matches] = (int)NUM_CMDS + i;
+              nr_matches++;
+
+              if (nr_matches >= CONFIG_READLINE_MAX_EXTCMDS)
+                {
+                  break;
+                }
+            }
+        }
+    }
+#endif
+
   return nr_matches;
 }
 #endif
@@ -1334,7 +1362,19 @@ int nsh_extmatch_count(FAR char *name, FAR int *matches, int namelen)
     defined(CONFIG_READLINE_HAVE_EXTMATCH)
 FAR const char *nsh_extmatch_getname(int index)
 {
-  DEBUGASSERT(index > 0 && index <= (int)NUM_CMDS);
-  return  g_cmdmap[index].cmd;
+  DEBUGASSERT(index >= 0);
+
+  if (index < (int)NUM_CMDS)
+    {
+      return g_cmdmap[index].cmd;
+    }
+
+#ifdef CONFIG_NSH_FILE_APPS
+  index -= (int)NUM_CMDS;
+  DEBUGASSERT(index >= 0 && index < (int)g_file_app_matches.count);
+  return g_file_app_matches.names[index];
+#else
+  return NULL;
+#endif
 }
 #endif

--- a/nshlib/nsh_fileapps_helper.c
+++ b/nshlib/nsh_fileapps_helper.c
@@ -1,0 +1,301 @@
+/****************************************************************************
+ * apps/nshlib/nsh_fileapps_helper.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifdef CONFIG_NSH_FILE_APPS
+
+#include <sys/stat.h>
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nsh.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: app_name_compare
+ *
+ * Description:
+ *   Comparison function for qsort to sort file app names
+ *
+ ****************************************************************************/
+
+static int app_name_compare(const void *a, const void *b)
+{
+  return strcmp(*(FAR const char * const *)a, *(FAR const char * const *)b);
+}
+
+/****************************************************************************
+ * Name: deduplicate_file_apps
+ *
+ * Description:
+ *   Sort and remove duplicate file app names
+ *
+ ****************************************************************************/
+
+static int deduplicate_file_apps(FAR struct file_app_info_s *info)
+{
+  unsigned int i;
+  unsigned int j;
+
+  if (info->count <= 1)
+    {
+      return OK;
+    }
+
+  qsort(info->names, info->count, sizeof(FAR char *), app_name_compare);
+
+  for (i = 0, j = 1; j < info->count; j++)
+    {
+      if (strcmp(info->names[i], info->names[j]) != 0)
+        {
+          i++;
+          if (i != j)
+            {
+              info->names[i] = info->names[j];
+            }
+        }
+      else
+        {
+          free(info->names[j]);
+        }
+    }
+
+  info->count = i + 1;
+  return OK;
+}
+
+/****************************************************************************
+ * Name: add_file_app
+ *
+ * Description:
+ *   Add a file app name to the collection (duplicates handled later)
+ *
+ ****************************************************************************/
+
+static int add_file_app(FAR struct file_app_info_s *info,
+                        FAR const char *name)
+{
+  FAR char **tmp;
+  FAR char *copy;
+
+  if (info->count >= info->alloc)
+    {
+      unsigned int alloc = info->alloc == 0 ? 16 : info->alloc * 2;
+
+      tmp = (FAR char **)realloc(info->names, alloc * sizeof(FAR char *));
+      if (tmp == NULL)
+        {
+          return -ENOMEM;
+        }
+
+      info->names = tmp;
+      info->alloc = alloc;
+    }
+
+  copy = strdup(name);
+  if (copy == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  info->names[info->count++] = copy;
+  return OK;
+}
+
+/****************************************************************************
+ * Name: is_executable_file_app
+ *
+ * Description:
+ *   Return true if the candidate path refers to a regular executable file.
+ *
+ ****************************************************************************/
+
+static bool is_executable_file_app(FAR const char *dirpath,
+                                   FAR const char *name)
+{
+  struct stat buf;
+  FAR char *filepath;
+  size_t dirlen;
+  size_t namelen;
+  int ret;
+
+  dirlen = strlen(dirpath);
+  namelen = strlen(name);
+  filepath = (FAR char *)malloc(dirlen + namelen + 2);
+  if (filepath == NULL)
+    {
+      return false;
+    }
+
+  memcpy(filepath, dirpath, dirlen);
+  filepath[dirlen] = '/';
+  memcpy(filepath + dirlen + 1, name, namelen + 1);
+
+  ret = stat(filepath, &buf);
+  free(filepath);
+  if (ret < 0)
+    {
+      return false;
+    }
+
+  if (!S_ISREG(buf.st_mode) ||
+      (buf.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) == 0)
+    {
+      return false;
+    }
+
+  return true;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nsh_free_file_apps
+ ****************************************************************************/
+
+void nsh_free_file_apps(FAR struct file_app_info_s *info)
+{
+  unsigned int i;
+
+  for (i = 0; i < info->count; i++)
+    {
+      free(info->names[i]);
+    }
+
+  free(info->names);
+  info->names = NULL;
+  info->count = 0;
+  info->alloc = 0;
+}
+
+/****************************************************************************
+ * Name: nsh_collect_path_file_apps
+ *
+ * Description:
+ *   Collect file app names from PATH for tab-completion cache population.
+ *
+ ****************************************************************************/
+
+int nsh_collect_path_file_apps(FAR struct file_app_info_s *info,
+                               FAR const char *prefix,
+                               int prefix_len)
+{
+  FAR char *pathenv;
+  FAR char *pathlist;
+  FAR char *saveptr = NULL;
+  FAR char *dirpath;
+
+  nsh_free_file_apps(info);
+
+#ifndef CONFIG_DISABLE_ENVIRON
+  pathenv = getenv("PATH");
+#else
+  pathenv = NULL;
+#endif
+
+  if (pathenv == NULL || pathenv[0] == '\0')
+    {
+      return OK;
+    }
+
+  pathlist = strdup(pathenv);
+  if (pathlist == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  for (dirpath = strtok_r(pathlist, ":", &saveptr);
+       dirpath != NULL;
+       dirpath = strtok_r(NULL, ":", &saveptr))
+    {
+      DIR *dirp;
+      FAR struct dirent *entryp;
+
+      if (dirpath[0] == '\0')
+        {
+          dirpath = ".";
+        }
+
+      dirp = opendir(dirpath);
+      if (dirp == NULL)
+        {
+          continue;
+        }
+
+      while ((entryp = readdir(dirp)) != NULL)
+        {
+          int ret;
+
+          if (strcmp(entryp->d_name, ".") == 0 ||
+              strcmp(entryp->d_name, "..") == 0)
+            {
+              continue;
+            }
+
+          if (DIRENT_ISDIRECTORY(entryp->d_type))
+            {
+              continue;
+            }
+
+          if (prefix_len > 0 &&
+              strncmp(entryp->d_name, prefix, prefix_len) != 0)
+            {
+              continue;
+            }
+
+          if (!is_executable_file_app(dirpath, entryp->d_name))
+            {
+              continue;
+            }
+
+          ret = add_file_app(info, entryp->d_name);
+          if (ret < 0)
+            {
+              closedir(dirp);
+              free(pathlist);
+              nsh_free_file_apps(info);
+              return ret;
+            }
+        }
+
+      closedir(dirp);
+    }
+
+  free(pathlist);
+  return deduplicate_file_apps(info);
+}
+
+#endif /* CONFIG_NSH_FILE_APPS */


### PR DESCRIPTION
## Summary

There is no command tab completion available
for file apps. This patch adds support for that, similar to what is
implemented for builtin apps.

## Impact

Static completion cache is allocated and re-populated each time the tab
completion is used. After first tab completion usage, this cache remains in
memory containing the latest tab completion results.